### PR TITLE
Fix default agent version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: java
+jdk:
+  - oraclejdk10
+script:
+  - mvn clean install -P dev
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: java
 jdk:
   - oraclejdk10
-script:
-  - mvn clean install -P dev
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -11,7 +11,31 @@
     <properties>
         <resteasy.version>3.5.0.Final</resteasy.version>
         <mockito.version>2.19.0</mockito.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
+
+    <profiles>
+        <profile>
+            <id>dev</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <build.profile.id>dev</build.profile.id>
+                <skip.integration.tests>true</skip.integration.tests>
+                <skip.unit.tests>false</skip.unit.tests>
+            </properties>
+        </profile>
+        <profile>
+            <id>IT</id>
+            <properties>
+                <build.profile.id>integration-test</build.profile.id>
+                <skip.integration.tests>false</skip.integration.tests>
+                <skip.unit.tests>true</skip.unit.tests>
+            </properties>
+        </profile>
+    </profiles>
 
     <dependencies>
         <dependency>
@@ -73,6 +97,11 @@
             <version>2.17.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <version>1.3</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -80,10 +109,61 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.7.0</version>
                 <configuration>
                     <source>10</source>
                     <target>10</target>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.0</version>
+                <configuration>
+                    <skipTests>${skip.unit.tests}</skipTests>
+                    <excludes>
+                        <exclude>**/IT*.java</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>2.22.0</version>
+                <executions>
+                    <execution>
+                        <id>integration-tests</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                        <configuration>
+                            <skipTests>${skip.integration.tests}</skipTests>
+                        </configuration>
+                    </execution>
+                </executions>
+                <configuration>
+                    <trimStackTrace>false</trimStackTrace>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.7.9</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
         <resources>

--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.7.9</version>
+                <version>0.8.1</version>
                 <executions>
                     <execution>
                         <goals>

--- a/src/main/java/org/igorski/services/SamebugClientFactory.java
+++ b/src/main/java/org/igorski/services/SamebugClientFactory.java
@@ -48,14 +48,14 @@ class SamebugClientFactory {
         ResteasyWebTarget webTarget = client.target(UriBuilder.fromPath(propertiesStore.getEndpoint()));
         webTarget.register((ClientRequestFilter) requestContext -> {
             requestContext.getHeaders().add("X-Samebug-ApiKey", propertiesStore.getApiKey());
-            requestContext.getHeaders().add("User-Agent", "JUnit-Extension/" + buildProperties.buildVersion);
+            requestContext.getHeaders().add("User-Agent", "JUnit-Extension/" + buildProperties.getBuildVersion());
         });
 
         samebugClient = webTarget.proxy(SamebugClient.class);
     }
 
     private class BuildProperties {
-        final String buildVersion;
+        private String buildVersion;
         static final String BUILD_PROPERTIES_FILE = "build.properties";
         static final String DEFAULT_BUILD_VERSION = "<undefined version>";
         static final String BUILD_VERSION_KEY = "version";
@@ -63,11 +63,18 @@ class SamebugClientFactory {
         BuildProperties() {
             var p = new Properties();
             try {
-                p.load(getClass().getResourceAsStream(BUILD_PROPERTIES_FILE));
+                p.load(getClass().getClassLoader().getResourceAsStream(BUILD_PROPERTIES_FILE));
             } catch (IOException e) {
                 LOGGER.warn("Failed to read client properties file!", e);
             }
             buildVersion =  p.getProperty(BUILD_VERSION_KEY, DEFAULT_BUILD_VERSION);
+            if(buildVersion.contains("${project.version}")) {
+                buildVersion = DEFAULT_BUILD_VERSION;
+            }
+        }
+
+        public String getBuildVersion() {
+            return buildVersion;
         }
     }
 }

--- a/src/test/java/org/igorski/services/SamebugProxyIT.java
+++ b/src/test/java/org/igorski/services/SamebugProxyIT.java
@@ -17,7 +17,7 @@ public class SamebugProxyIT {
         server.stubFor(
                 post(urlEqualTo("/crashes"))
                         .withHeader("X-Samebug-ApiKey", containing("apiKey"))
-                        .withHeader("User-Agent", containing("JUnit-Extension/1.0.0"))
+                        .withHeader("User-Agent", containing("JUnit-Extension/<undefined version>"))
                         .willReturn(aResponse()
                                 .withHeader("Content-Type", "application/json")
                                 .withBody("{\n" +


### PR DESCRIPTION
The value for the agent is never null. If it is not run
with maven then the value will be ${project.version}. A check is
added. If that is the case then the value is replaced with the
default value. In addition the IT test is changed to expect the
default value.